### PR TITLE
Fix off-by-one error in ep_opf65 and ep_opf55

### DIFF
--- a/main.s
+++ b/main.s
@@ -674,6 +674,7 @@ ep_opf:
 		lea rsi, program[rip]
 		add rsi, rax
 		lea rdi, program_regs[rip]
+		inc rcx
 		rep movsb
 		jmp ep_loop
 
@@ -759,6 +760,7 @@ ep_opf:
 		movzx rax, word ptr program_regi[rip]
 		lea rdi, program[rip]
 		add rdi, rax
+		inc rcx
 		rep movsb
 		jmp ep_loop
 ep_quit:


### PR DESCRIPTION
I tried running the Trip8 Demo ROM, and I saw a bug that I remember seeing on my own emulator!

I fixed an off-by-one bug in the ep_opf65 and ep_opf55 instructions, and now Trip8 seems to run perfectly.